### PR TITLE
fix(0020-py-version-support): update for Tiamat

### DIFF
--- a/accepted/0020-py-version-support.md
+++ b/accepted/0020-py-version-support.md
@@ -29,9 +29,8 @@ for that operating system.
 Including Python in Packages
 ----------------------------
 Another motivating factor to make this policy change is our shift to including Python in our
-packages. For the Sodium release we will be using pop-build (https://gitlab.com/saltstack/pop/pop-build/) to
-package for our Fully Supported Platforms.
-(http://get.saltstack.com/rs/304-PHQ-615/images/SaltStack-Supported-Operating-Systems.pdf)
+packages. For the Sodium release we will be using [Tiamat](https://gitlab.com/saltstack/pop/tiamat/) (previously known as [pop-build](https://gitlab.com/saltstack/pop/pop-build/)) to
+package for our [Fully Supported Platforms](http://get.saltstack.com/rs/304-PHQ-615/images/SaltStack-Supported-Operating-Systems.pdf).
 This will allow us to easily continue supporting operating systems that include End of Life Python
 versions by default by providing the Python binary in the Salt package included in a Salt release.
 


### PR DESCRIPTION
CC: @Ch3LL.

https://gitlab.com/saltstack/pop/pop-build is deprecated and shows the following warning:

> Deletion pending. This project will be removed on 2020-06-06. Repository and other project resources are read-only.

Updated to Tiamat and improved some of the hyperlinks.

Here's a link to the specific paragraph that's been changed:

* https://github.com/saltstack/salt-enhancement-proposals/blob/aa2ea65fe0a8b19bce45e07a77b7deb4a4e004ea/accepted/0020-py-version-support.md#including-python-in-packages