### PR TITLE
SEP 19: Improve running salts under user privileges/accounts

### DIFF
--- a/0019-master-non-root.md
+++ b/0019-master-non-root.md
@@ -68,6 +68,7 @@ The usage of `root` in ACL's could therefore be deprecated and replaced by `salt
 * Everything for `root` goes also for Windows' `SYSTEM`? 
 * The myriad of pillars/engines etc might require additional configuration/access/documentation if they access local files/sockets
 * `XDG_` equivalents on Mac, Win, BSD, etc.
+* grains; if salt-master is configured to load these, how many of those need `root` and how graceful do they fail
 
 ## `syspaths`
 
@@ -79,12 +80,19 @@ various levels of flexibility to the syspaths could be introduced to facilitate 
 [drawbacks]: #drawbacks
 
 * Everyone currently using centralized configs for their non-root invocations of salt cli's will eventually need to put in config in their profile
-** this might be slightly alleviated by altering the coalesce for e.g. salt-master socket locally
-** a salt-minion socket equivalent might be introduced?
+  * this might be slightly alleviated by altering the coalesce for e.g. salt-master socket locally
+  * a salt-minion socket equivalent might be introduced?
 * in my experience the vast majority just `sudo` as user bypassing this problem altogether
 * still using PAM; a cursory glance of PyPI shows this not to be a popular option at all
 * excessive reading of the config causes excessive cascading causes slowdowns
 * introduce 'mappings' to ACLs?
+
+# Alternatives
+
+* socket auth
+* improve SSO capabilities
+* deprecate PAM altogether
+* ship daemons built with system paths, ship user cli utils with XDG behaviours 
 
 # References
 

--- a/0019-master-non-root.md
+++ b/0019-master-non-root.md
@@ -1,4 +1,4 @@
-- Feature Name: [security] run salt-master non-root by default
+- Feature Name: [security] Improve the default behaviour of salt when running under different scenario's than as `root`
 - Start Date: 2020-02-28
 - SEP Status: Draft
 - SEP PR: 25
@@ -7,56 +7,89 @@
 # Summary
 [summary]: #summary
 
-Running any server application, typically accessible via the internet, as root user is a security risk.
-Bugs _do_ happen, in any application.   Apps should run with as little rights as possible.
+Salt has always assumed running as root for all of it's deployment scenarios. 
+As a consequence, it has always required multiple manual configuration and directory configurations to get salt in it's many incarnations to work under non-root privileges.
 
-Salt-master by default, runs as root user and salt documents how you can run salt-server as non root.(https://docs.saltstack.com/en/latest/ref/configuration/nonroot.html) 
+It has long been a standing best-practice to run serving daemons under regular user privileges, opening up additional capabilities as necessary.
+The core salt master has very little need for these additional capabilities, and these requirements can be orchestrated otherwise.
 
-This is the wrong way around.  It should run as non-root by default. And document when/why/how you can run it as root.
+Improving the default behaviour would additionally make salt more convenient to deploy and use in stand-alone/multi-minion scenario's (e.g. salt-ssh from a multi-user bastion) and containers. 
 
-If I read the documentation correctly its PAM external auth that breaks when running as non-root (https://github.com/saltstack/salt/issues/7762)
-If that really cannot be fixed in salt, then the Salt PAM external auth documentation should mention how you can change your salt installation to run as root.
-
-Brief explanation of the feature.
 
 # Motivation
 [motivation]: #motivation
 
-Filed as SEP as suggested by Ch3LL in https://github.com/saltstack/salt/issues/55886
+* Initially filed as SEP as suggested by Ch3LL in [#55886](https://github.com/saltstack/salt/issues/55886)
+* Make salt more flexible/easy to use in non-root scenario's
+* Make salt-master safer to deploy by running it under locked down privileges by default
+* Make salt align and integrate better with the wider ecosystem
+
+# Design concepts
+[design]: #design-concepts
+
+## Salt behaviours
+
+`salt-{master,minion,ssh,cloud}` start conforming to the XDG application directory standards
+* run as `root` or `salt`: current syspath defaults
+* run as user: `${XDG_{CACHE,CONFIG,DATA}_HOME}/salt/{master,minion,ssh,cloud}` etc.
+* all necessary dirs are created if nonexistent
+* the salt config `user` and SSH equivalent both default to the running user
+* all configs written are written by default to a separate config dir, e.g. `_generated.d`
+
+## OS package changes
+
+* install system user/group `salt` 
+* change init-scripts to invoke as `salt` and override XDG default back to `/etc/salt/<daemon>/daemon.conf`
+* install all `/etc/salt` dirs owned by `root:salt` `750`
+* install `/var/cache/salt` and `/srv/salt` etc. owned by `salt:salt` `770`
+* allow writing on `/etc/salt/pki` dirs and `/etc/salt/<daemon>/_generated.d` dirs
+* allow `salt` access to `/etc/shadow`
+
+## PAM
+
+[The documentation](https://docs.saltstack.com/en/latest/ref/auth/all/salt.auth.pam.html#module-salt.auth.pam) states it does not support authenticating as root.
+Besides, at least one serious issue ([#7762](https://github.com/saltstack/salt/issues/7762)) stated for this to be broken because at any rate the salt running user needs access to `/etc/shadow`.
+
+Because the `salt-master` executing the commands would now be running as `salt`, that can be considered the highest achievable named authority within the Salt master.
+The usage of `root` in ACL's could therefore be deprecated and replaced by `salt`.
 
 
-# Design
-[design]: #detailed-design
+## Migration paths
 
-Salt master should be installed an run unpriviliged.
+* if `user` is set manually, show deprecation/path default change warning
+* stop `user` config usage and support eventually, making `user` a runtime variable
+* `runas` / elevation scenario's
+* all user ACL's to `root` get deprecation warnings to change to `salt`
 
-Installation scripts should install it as the proper user, chmod the proper directories etc.
-
-
-
-## Alternatives
-[alternatives]: #alternatives
-
-To get a secured by default installation, I don't think there are any alternatives.
-
-## Unresolved questions
+# Unresolved questions
 [unresolved]: #unresolved-questions
 
-How to handle loading of configuration files has to be addressed.
+* `salt` as top-ACL user is still a hard-code
+* Everything for `root` goes also for Windows' `SYSTEM`? 
+* The myriad of pillars/engines etc might require additional configuration/access/documentation if they access local files/sockets
+* `XDG_` equivalents on Mac, Win, BSD, etc.
 
-I see multiple possible sollutions for this.
-A) We can start salt-master as an unpriviledged user, and that unpriviledged user has read access to the configuration files via group read permissions.
-B) We can start salt-master as root, and let the application fallback to an unpriviledged users after reading the configuration files. (similar to what nginx for example does)
+## `syspaths`
 
-
+various levels of flexibility to the syspaths could be introduced to facilitate this, e.g.
+* additional coalescing default items in `syspaths.py` and/or `config`
+* generating & loading a `_syspaths.py` to cache
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-The documentation (https://docs.saltstack.com/en/latest/ref/configuration/nonroot.html) mentions PAM external auth as a reason why salt master runs as root.
+* Everyone currently using centralized configs for their non-root invocations of salt cli's will eventually need to put in config in their profile
+** this might be slightly alleviated by altering the coalesce for e.g. salt-master socket locally
+** a salt-minion socket equivalent might be introduced?
+* in my experience the vast majority just `sudo` as user bypassing this problem altogether
+* still using PAM; a cursory glance of PyPI shows this not to be a popular option at all
+* excessive reading of the config causes excessive cascading causes slowdowns
+* introduce 'mappings' to ACLs?
 
-I'm not 100% familiar with PAM external auth, but I suspect that particular issue can even be fixed.
-pam_unix has a setuid helper (unix_chkpwd) that seems exactly intended for this. For applications, without read access to /etc/shadow/ to do authentication.
+# References
 
-
-Even if the PAM external auth issue cannot be fixed, then still we should run salt master, by default, as non root. And document what a uses needs to change to use PAM external auth. (which most probably don't use)
+* [Running the Salt Master/Minion as an Unprivileged User](https://docs.saltstack.com/en/latest/ref/configuration/nonroot.html)
+* [Running salt as normal user tutorial](https://docs.saltstack.com/en/latest/topics/tutorials/rooted.html)
+* [django-pam](https://pypi.org/project/django-pam/)
+* [pamela](https://pypi.org/project/pamela/)
+* [radicale-auth-PAM](https://pypi.org/project/radicale-auth-PAM/)


### PR DESCRIPTION
Request for Comments ;)

# Aims
* Salt daemons (minion excluded?) running default under system-user credentials
* Salt CLI tools use XDG/other relevant standard locations

# References
* Continuation of #25
* https://github.com/saltstack/salt/issues/55886
