### PR TITLE
SEP 31: Replace freenode references with liberachat.

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -15,7 +15,7 @@ newIssueWelcomeComment: >
       - [Community Wiki](https://github.com/saltstack/community/wiki)
       - [Salt’s Contributor Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html)
       - [Join our Community Slack](https://saltstackcommunity.herokuapp.com/)
-      - [IRC on Freenode](https://webchat.freenode.net/#salt)
+      - [IRC on LiberaChat](https://web.libera.chat/#salt)
       - [SaltStack YouTube channel](https://www.youtube.com/user/SaltStack)
       - [SaltStackInc Twitch channel](https://www.twitch.tv/saltstackinc)
 
@@ -34,7 +34,7 @@ newPRWelcomeComment: >
       - [Community Wiki](https://github.com/saltstack/community/wiki)
       - [Salt’s Contributor Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html)
       - [Join our Community Slack](https://saltstackcommunity.herokuapp.com/)
-      - [IRC on Freenode](https://webchat.freenode.net/#salt)
+      - [IRC on LiberaChat](https://web.libera.chat/#salt)
       - [SaltStack YouTube channel](https://www.youtube.com/user/SaltStack)
       - [SaltStackInc Twitch channel](https://www.twitch.tv/saltstackinc)
 

--- a/accepted/0014-dev-overhaul.md
+++ b/accepted/0014-dev-overhaul.md
@@ -118,7 +118,7 @@ One major challenge for the community is understanding changes coming in the nex
 
 Salt [documentation](https://docs.saltstack.com) will be updated to point to the most current release (2019.2.1 at the time of this writing). For users who have not yet upgraded, or those who are testing the unreleased version of Salt, Salt take an approach similar to the official Python documentation, and have a drop-down or some other way to easily select documentation for other Salt versions.
 
-We will also upgrade our communication processes to keep the Salt community more aware of the release timelines. We will share progress with the [#salt channel on IRC on Freenode](http://webchat.freenode.net/?channels=salt&uio=Mj10cnVlJjk9dHJ1ZSYxMD10cnVl83), the #release channel in the [SaltStack Community Slack](https://saltstackcommunity.herokuapp.com/), and the [Salt Users mailing list](https://groups.google.com/forum/#!forum/salt-users).
+We will also upgrade our communication processes to keep the Salt community more aware of the release timelines. We will share progress with the [#salt channel on IRC on LiberaChat](https://web.libera.chat/#salt), the #release channel in the [SaltStack Community Slack](https://saltstackcommunity.herokuapp.com/), and the [Salt Users mailing list](https://groups.google.com/forum/#!forum/salt-users).
 
 ## Versioning (Naming)
 
@@ -143,7 +143,7 @@ Long and unpredictable release times, unstable branches, missing (or extra) fixe
 ## Unresolved questions
 [unresolved]: #unresolved-questions
 
-Hopefully all the questions have been answered in this SEP. Upgrading Salt should continue to work like it always has - our changes are focused on the external development process of Salt. If you feel like you have unanswered questions, please come ask them at the Salt Office Hours on October 1st, 2019, or find us in [#salt on IRC on Freenode](http://webchat.freenode.net/?channels=salt&uio=Mj10cnVlJjk9dHJ1ZSYxMD10cnVl83), the [SaltStack Community Slack](https://saltstackcommunity.herokuapp.com/), or the [Salt Users mailing list](https://groups.google.com/forum/#!forum/salt-users).
+Hopefully all the questions have been answered in this SEP. Upgrading Salt should continue to work like it always has - our changes are focused on the external development process of Salt. If you feel like you have unanswered questions, please come ask them at the Salt Office Hours on October 1st, 2019, or find us in [#salt on IRC on LiberaChat](https://web.libera.chat/#salt), the [SaltStack Community Slack](https://saltstackcommunity.herokuapp.com/), or the [Salt Users mailing list](https://groups.google.com/forum/#!forum/salt-users).
 
 # Drawbacks
 [drawbacks]: #drawbacks


### PR DESCRIPTION
Freenode staff have now rolled out two waves of hostile channel
takeovers on the Freenode network. The #salt channel that served as
SaltStack'ss/SaltProject's primary IRC channel for many years is one
such channel that was taken over.

We have largely already migrated to the new LiberaChat network.

See saltstack/salt#60261